### PR TITLE
Remove hardcoded filters for benefit cards

### DIFF
--- a/handlers/credit_card.py
+++ b/handlers/credit_card.py
@@ -14,8 +14,8 @@ class Handler(BaseHandler):
         '3(?:0[0-5]|[68][0-9])[0-9]{11}',
         '6(?:011|5[0-9]{2})[0-9]{12}',
         '(?:2131|1800|35\d{3})\d{11}',
-        '\d{13,16}',
-        '(\d{4,6}.?){4}',
+     #   '\d{13,16}',
+     #   '(\d{4,6}.?){4}',
     ]
 
     def process(self, channel, user, ts, message, at_bot, command, **kwargs):


### PR DESCRIPTION
Before the production of zelda and mPOS for "MEIs" we do not share too much data from benefit cards and we can't find a solution (regex) that could allow us to change and filter only sodexo/vr/va/alelo cards. Actually, they buy different BIN ranges and we could only use the BIN as regex but it would take time as they have plenty of different ranges and are continuously changing and adding more (that would set for us continuous tasks of updating the list and regexes), and that is the case of Alelo mainly, the others we know very few about the patterns.