### PR TITLE
Fix: RegEx credit card audit

### DIFF
--- a/credit_card_interceptor.go
+++ b/credit_card_interceptor.go
@@ -24,6 +24,8 @@ func CreditCardInterceptorStart() {
 		"6(?:011|5[0-9]{2})[0-9]{12}"), Handler: CreditCardFoundInterceptor, Continue: false})
 	AddInterceptor(Interceptor{Regex: regexp.MustCompile(
 		"(?:2131|1800|35\\d{3})\\d{11}"), Handler: CreditCardFoundInterceptor, Continue: false})
+	AddInterceptor(Interceptor{Regex: regexp.MustCompile(
+		"\\|[0-9]{4}-[0-9]{4}-[0-9]{4}>-[0-9]{4}"), Handler: CreditCardFoundInterceptor, Continue: false})
 
 }
 


### PR DESCRIPTION
When somebody sends a credit card with dash in Slack, Its return's like a phone number `<tel:4111-4111-4111|4111-4111-4111>-4111`.

We had to change the RegEx to delete the message and return the PCI's message.