### PR TITLE
Add a command to block a request based on string matches

### DIFF
--- a/waf_handler.go
+++ b/waf_handler.go
@@ -3,11 +3,12 @@ package secbot
 import (
 	"errors"
 	"fmt"
+	"regexp"
+	"strings"
+
 	"github.com/aws/aws-sdk-go/service/waf"
 	"github.com/aws/aws-sdk-go/service/wafregional"
 	"github.com/nlopes/slack"
-	"regexp"
-	"strings"
 )
 
 func WAFHandlerStart() {

--- a/waf_handler.go
+++ b/waf_handler.go
@@ -758,15 +758,26 @@ func WAFBlockRequestFieldTypeCommand(md map[string]string, ev *slack.MessageEven
 	value := []byte(md["value"])
 	stringMatch := waf.ByteMatchTuple{PositionalConstraint: &matchType, TargetString: value, TextTransformation: &transformationType}
 
-	if strings.EqualFold(md["type"], "body") {
+	fieldType := md["type"]
+	switch {
+	case strings.EqualFold(fieldType, "body"):
 		fieldTypeBody := waf.MatchFieldTypeBody
 		fieldTypeMatch := waf.FieldToMatch{Type: &fieldTypeBody}
 		stringMatch.SetFieldToMatch(&fieldTypeMatch)
-	} else if strings.EqualFold(md["type"], "uri") {
+	case strings.EqualFold(fieldType, "uri"):
 		fieldTypeUri := waf.MatchFieldTypeUri
 		fieldTypeMatch := waf.FieldToMatch{Type: &fieldTypeUri}
 		stringMatch.SetFieldToMatch(&fieldTypeMatch)
-	} else {
+		stringMatch.SetFieldToMatch(&fieldTypeMatch)
+	case strings.EqualFold(fieldType, "method"):
+		fieldTypeMethod := waf.MatchFieldTypeMethod
+		fieldTypeMatch := waf.FieldToMatch{Type: &fieldTypeMethod}
+		stringMatch.SetFieldToMatch(&fieldTypeMatch)
+	case strings.EqualFold(fieldType, "query_string"):
+		fieldTypeQueryString := waf.MatchFieldTypeQueryString
+		fieldTypeMatch := waf.FieldToMatch{Type: &fieldTypeQueryString}
+		stringMatch.SetFieldToMatch(&fieldTypeMatch)
+	default:
 		PostMessage(ev.Channel, fmt.Sprintf("Campo %s ainda não foi implementado", md["type"]))
 		return
 	}
@@ -854,15 +865,26 @@ func WAFUnblockRequestFieldTypeCommand(md map[string]string, ev *slack.MessageEv
 	value := []byte(md["value"])
 	stringMatch := waf.ByteMatchTuple{PositionalConstraint: &matchType, TargetString: value, TextTransformation: &transformationType}
 
-	if strings.EqualFold(md["type"], "body") {
+	fieldType := md["type"]
+	switch {
+	case strings.EqualFold(fieldType, "body"):
 		fieldTypeBody := waf.MatchFieldTypeBody
 		fieldTypeMatch := waf.FieldToMatch{Type: &fieldTypeBody}
 		stringMatch.SetFieldToMatch(&fieldTypeMatch)
-	} else if strings.EqualFold(md["type"], "uri") {
+	case strings.EqualFold(fieldType, "uri"):
 		fieldTypeUri := waf.MatchFieldTypeUri
 		fieldTypeMatch := waf.FieldToMatch{Type: &fieldTypeUri}
 		stringMatch.SetFieldToMatch(&fieldTypeMatch)
-	} else {
+		stringMatch.SetFieldToMatch(&fieldTypeMatch)
+	case strings.EqualFold(fieldType, "method"):
+		fieldTypeMethod := waf.MatchFieldTypeMethod
+		fieldTypeMatch := waf.FieldToMatch{Type: &fieldTypeMethod}
+		stringMatch.SetFieldToMatch(&fieldTypeMatch)
+	case strings.EqualFold(fieldType, "query_string"):
+		fieldTypeQueryString := waf.MatchFieldTypeQueryString
+		fieldTypeMatch := waf.FieldToMatch{Type: &fieldTypeQueryString}
+		stringMatch.SetFieldToMatch(&fieldTypeMatch)
+	default:
 		PostMessage(ev.Channel, fmt.Sprintf("Campo %s ainda não foi implementado", md["type"]))
 		return
 	}

--- a/waf_handler.go
+++ b/waf_handler.go
@@ -101,6 +101,18 @@ func WAFHandlerStart() {
 		}})
 
 	AddCommand(Command{
+		Regex:              regexp.MustCompile("waf (?P<command>unblock) (?P<type>(?i)(header|method|query_string|uri|body)) (?P<value>\\S+)"),
+		Help:               "Desbloqueia por tipo do campo da requisição no WAF",
+		Usage:              "waf unblock <header|method|query_string|uri|body> <value> ",
+		Handler:            WAFUnblockRequestFieldTypeCommand,
+		RequiredPermission: "waf",
+		HandlerName:        "waf",
+		Parameters: map[string]string{
+			"type":  "(?i)(header|method|query_string|uri|body)",
+			"value": "\\S+",
+		}})
+
+	AddCommand(Command{
 		Regex:              regexp.MustCompile("waf (?P<command>set default account) (?P<account>\\S+)"),
 		Help:               "Define a conta padrão do WAF",
 		Usage:              "waf set default account <account>",
@@ -760,6 +772,102 @@ func WAFBlockRequestFieldTypeCommand(md map[string]string, ev *slack.MessageEven
 	}
 
 	action := waf.ChangeActionInsert
+	var stringMatchUpdates []*waf.ByteMatchSetUpdate
+	stringMatchUpdates = append(stringMatchUpdates, &waf.ByteMatchSetUpdate{Action: &action, ByteMatchTuple: &stringMatch})
+
+	token, err := WAFGetToken(wafr)
+
+	if err != nil {
+		PostMessage(ev.Channel, fmt.Sprintf("@%s Ocorreu um erro obtendo o token: %s", ev.Username, err.Error()))
+		return
+	}
+
+	updateinput := waf.UpdateByteMatchSetInput{
+		ChangeToken:    &token,
+		ByteMatchSetId: byteset.ByteMatchSet.ByteMatchSetId,
+		Updates:        stringMatchUpdates,
+	}
+
+	_, err = wafr.UpdateByteMatchSet(&updateinput)
+
+	if err != nil {
+		PostMessage(ev.Channel, fmt.Sprintf("Ocorreu um erro ao atualizar a condition: %s", err.Error()))
+		return
+	}
+
+	PostMessage(ev.Channel, fmt.Sprintf("Condition atualizada com sucesso."))
+}
+
+/*
+Unblock the specified String in the field type on the account's WAF
+
+HandlerName
+
+ waf
+
+RequiredPermission
+
+ waf
+
+Regex
+
+ waf (?P<command>unblock) (?P<type>(?i)(header|method|query_string|uri|body)) (?<value>\\S+)
+
+Usage
+
+ waf unblock <header|method|query_string|uri|body> <value>
+*/
+
+func WAFUnblockRequestFieldTypeCommand(md map[string]string, ev *slack.MessageEvent) {
+
+	avalid, account := WAFValidateAccount(md)
+
+	if !avalid {
+		PostMessage(ev.Channel, fmt.Sprintf("@%s nenhuma conta especificada e conta padrão não configurada\n"+
+			"Utilize `waf set default acccount <account>` "+
+			"ou invoque novamente o comando especificando a conta", ev.Username))
+		return
+	}
+
+	rvalid, region := WAFValidateRegion(md)
+
+	if !rvalid {
+		PostMessage(ev.Channel, fmt.Sprintf("@%s nenhuma região especificada e região padrão não configurada\n"+
+			"Utilize `waf set default region <region>` "+
+			"ou invoque novamente o comando especificando a conta", ev.Username))
+		return
+	}
+
+	sess, _ := AWSGetSession(account, region)
+
+	wafr := wafregional.New(sess)
+
+	byteset, err := WAFGetByteMatchSetByName(wafr, WAFGetCurrentByteMatchSet())
+
+	if err != nil {
+		PostMessage(ev.Channel, fmt.Sprintf("Erro ao tentar pegar a condition %s: %s", WAFGetCurrentByteMatchSet(), err.Error()))
+		return
+	}
+
+	matchType := waf.PositionalConstraintContains
+	transformationType := waf.TextTransformationNone
+	value := []byte(md["value"])
+	stringMatch := waf.ByteMatchTuple{PositionalConstraint: &matchType, TargetString: value, TextTransformation: &transformationType}
+
+	if strings.EqualFold(md["type"], "body") {
+		fieldTypeBody := waf.MatchFieldTypeBody
+		fieldTypeMatch := waf.FieldToMatch{Type: &fieldTypeBody}
+		stringMatch.SetFieldToMatch(&fieldTypeMatch)
+	} else if strings.EqualFold(md["type"], "uri") {
+		fieldTypeUri := waf.MatchFieldTypeUri
+		fieldTypeMatch := waf.FieldToMatch{Type: &fieldTypeUri}
+		stringMatch.SetFieldToMatch(&fieldTypeMatch)
+	} else {
+		PostMessage(ev.Channel, fmt.Sprintf("Campo %s ainda não foi implementado", md["type"]))
+		return
+	}
+
+	action := waf.ChangeActionDelete
 	var stringMatchUpdates []*waf.ByteMatchSetUpdate
 	stringMatchUpdates = append(stringMatchUpdates, &waf.ByteMatchSetUpdate{Action: &action, ByteMatchTuple: &stringMatch})
 

--- a/waf_handler.go
+++ b/waf_handler.go
@@ -114,6 +114,16 @@ func WAFHandlerStart() {
 			"ipset": ".*",
 		}})
 
+	AddCommand(Command{
+		Regex:              regexp.MustCompile("waf (?P<command>set current bytematchset) (?P<bytematchset>.*)"),
+		Help:               "Define a condition atual usando bytematchset no WAF",
+		Usage:              "waf set current bytematchset <bytematchset>",
+		Handler:            WAFSetCurrentByteMatchSetCommand,
+		RequiredPermission: "waf",
+		HandlerName:        "waf",
+		Parameters: map[string]string{
+			"bytematchset": ".*",
+		}})
 }
 
 func WAFGetProfilesWithDefault() []string {
@@ -235,6 +245,33 @@ func WAFSetDefaultIPSetCommand(md map[string]string, ev *slack.MessageEvent) {
 	SetHandlerConfig("waf", "default_ipset", md["ipset"])
 	PostMessage(ev.Channel, fmt.Sprintf("@%s IPSet padrão setada para `%s`",
 		ev.Username, md["ipset"]))
+
+}
+
+/*
+Sets the current StringMatch condition.
+
+HandlerName
+
+ waf
+
+RequiredPermission
+
+ waf
+
+Regex
+
+ waf (?P<command>set current bytematchset) (?P<bytematchset>\\S+)"
+
+Usage
+
+ waf set current bytematchset <bytematchset>
+*/
+func WAFSetCurrentByteMatchSetCommand(md map[string]string, ev *slack.MessageEvent) {
+
+	SetHandlerConfig("waf", "current_bytematchset", md["bytematchset"])
+	PostMessage(ev.Channel, fmt.Sprintf("@%s ByteMatchSet atual setada para `%s`",
+		ev.Username, md["bytematchset"]))
 
 }
 


### PR DESCRIPTION
This code add the capability of block a request based on string match conditions. You can filter a request based on uri, body, method and query_string. Header filter was not implemented.

This closes that issue https://github.com/pagarme/heartbeat/issues/357